### PR TITLE
大佬，发现您的项目引入了org.hibernate:hibernate-validator@5.4.1.Final组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -39,7 +38,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>5.4.1.Final</version>
+            <version>6.0.19.Final</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Red Hat Hibernate Validator 安全漏洞
缺陷组件：org.hibernate:hibernate-validator@5.4.1.Final
漏洞编号：CVE-2017-7536
漏洞描述：Red Hat Hibernate Validator是美国红帽（Red Hat）公司的一套Bean验证框架，它能够验证遵循JavaBean规范编写的Java类，也可使用注解指定一个JavaBean上的约束。
Red Hat Hibernate Validator 5.2.5 finalZ之前的5.2.x 版本、5.3.x版本和5.4.x版本中存在安全漏洞。本地攻击者可借助‘ConstraintViolation＃getInvalidValue()’函数利用该漏洞获取提升的权限。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2018-03216
影响范围：[5.4.0.Final, 5.4.2.Final)
最小修复版本：6.0.19.Final
缺陷组件引入路径：com.example:validation@0.0.1-SNAPSHOT->org.hibernate:hibernate-validator@5.4.1.Final
```
另外我运行这个项目时，IDE的安全插件提示还有2个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p98d9f